### PR TITLE
Create repo-lockdown GitHub action

### DIFF
--- a/.github/workflows/lockdown.yml
+++ b/.github/workflows/lockdown.yml
@@ -1,0 +1,22 @@
+name: 'Repo Lockdown'
+
+on:
+  issues:
+    types: opened
+  pull_request_target:
+    types: opened
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v2
+        with:
+          issue-comment: 'Epic Games does not accept issues on this repository. Please visit https://www.unrealengine.com/support for support.'
+          pr-comment: 'Epic Games does not accept pull requests on this repository. Please visit https://www.unrealengine.com/support for support.'


### PR DESCRIPTION
This change adds a new GitHub action which automatically closes all GitHub issues or pull requests and redirects users to Unreal Engine support.